### PR TITLE
OST-2024 | Sort by exp and nodable order

### DIFF
--- a/spec/concerns/queue_it/queable_by_name_spec.rb
+++ b/spec/concerns/queue_it/queable_by_name_spec.rb
@@ -44,6 +44,38 @@ describe 'Concerns::QueableByName' do
   end
 
   describe '#pop' do
+    it "should return the first node in the queue sorted by field and nodable order" do
+      task.queue("cops").push(create(:user, name: "Edward"))
+      task.queue("cops").push(create(:user, name: "Amy"))
+      task.queue("cops").push(create(:user, name: "Bob"))
+      task.queue("cops").push(create(:user, name: "David"))
+      task.queue("cops").push(create(:user, name: "Cindy"))
+      task.queue("cops").push(create(:user, name: "Frank"))
+
+      handle_time = {
+        "Amy" => 0,
+        "Bob" => 0,
+        "David" => 1,
+        "Cindy" => 0,
+        "Edward" => 2,
+        "Frank" => 0
+      }
+
+      result = task.queue("cops").pop(
+        sort_exp: ->(u) { handle_time[u.name] },
+        sort_order: :asc
+      )
+      expect(result.name).to eq("Edward")
+      expect(task.queue("cops").nodes.count).to eq(5)
+
+      result = task.queue("cops").pop(
+        sort_exp: ->(u) { handle_time[u.name] },
+        sort_order: :desc
+      )
+      expect(result.name).to eq("Amy")
+      expect(task.queue("cops").nodes.count).to eq(4)
+    end
+
     it "should return the first node in the queue sorted by field" do
       task.queue("cops").push(create(:user, name: "John"))
       task.queue("cops").push(create(:user, name: "Bob"))
@@ -86,6 +118,38 @@ describe 'Concerns::QueableByName' do
   end
 
   describe '#shift' do
+    it "should return the first node in the queue sorted by field and nodable order" do
+      task.queue("cops").push(create(:user, name: "Edward"))
+      task.queue("cops").push(create(:user, name: "Amy"))
+      task.queue("cops").push(create(:user, name: "Bob"))
+      task.queue("cops").push(create(:user, name: "David"))
+      task.queue("cops").push(create(:user, name: "Cindy"))
+      task.queue("cops").push(create(:user, name: "Frank"))
+
+      handle_time = {
+        "Amy" => 0,
+        "Bob" => 0,
+        "David" => 1,
+        "Cindy" => 0,
+        "Edward" => 2,
+        "Frank" => 0
+      }
+
+      result = task.queue("cops").shift(
+        sort_exp: ->(u) { handle_time[u.name] },
+        sort_order: :asc
+      )
+      expect(result.name).to eq("Amy")
+      expect(task.queue("cops").nodes.count).to eq(5)
+
+      result = task.queue("cops").shift(
+        sort_exp: ->(u) { handle_time[u.name] },
+        sort_order: :desc
+      )
+      expect(result.name).to eq("Edward")
+      expect(task.queue("cops").nodes.count).to eq(4)
+    end
+
     it "should return the first node in the queue sorted by field" do
       task.queue("cops").push(create(:user, name: "John"))
       task.queue("cops").push(create(:user, name: "Bob"))
@@ -128,6 +192,36 @@ describe 'Concerns::QueableByName' do
   end
 
   describe '#nodables' do
+    it "should return the nodes in the queue sorted using the given sort expression and nodable order" do
+      task.queue("cops").push(create(:user, name: "Edward"))
+      task.queue("cops").push(create(:user, name: "Amy"))
+      task.queue("cops").push(create(:user, name: "Bob"))
+      task.queue("cops").push(create(:user, name: "David"))
+      task.queue("cops").push(create(:user, name: "Cindy"))
+      task.queue("cops").push(create(:user, name: "Frank"))
+
+      handle_time = {
+        "Amy" => 0,
+        "Bob" => 0,
+        "David" => 1,
+        "Cindy" => 0,
+        "Edward" => 2,
+        "Frank" => 0
+      }
+
+      result = task.queue("cops").nodables(
+        sort_exp: ->(u) { handle_time[u.name] },
+        sort_order: :asc
+      )
+      expect(result.map(&:name)).to eq(%w(Amy Bob Cindy Frank David Edward))
+
+      result = task.queue("cops").nodables(
+        sort_exp: ->(u) { handle_time[u.name] },
+        sort_order: :desc
+      )
+      expect(result.map(&:name)).to eq(%w(Edward David Frank Cindy Bob Amy))
+    end
+
     it "should return the nodes in the queue sorted using the given sort expression and sort order" do
       task.queue("cops").push(create(:user, name: "Bob"))
       task.queue("cops").push(create(:user, name: "Xia"))
@@ -194,6 +288,31 @@ describe 'Concerns::QueableByName' do
   end
 
   describe '#peek' do
+    it "should return the first node in the queue sorted by field and nodable order" do
+      task.queue("cops").push(create(:user, name: "Edward"))
+      task.queue("cops").push(create(:user, name: "Amy"))
+      task.queue("cops").push(create(:user, name: "Bob"))
+      task.queue("cops").push(create(:user, name: "David"))
+      task.queue("cops").push(create(:user, name: "Cindy"))
+      task.queue("cops").push(create(:user, name: "Frank"))
+
+      handle_time = {
+        "Amy" => 0,
+        "Bob" => 0,
+        "David" => 1,
+        "Cindy" => 0,
+        "Edward" => 2,
+        "Frank" => 0
+      }
+
+      result = task.queue("cops").peek(
+        sort_exp: ->(u) { handle_time[u.name] },
+        sort_order: :asc
+      )
+      expect(result.name).to eq("Amy")
+      expect(task.queue("cops").nodes.count).to eq(6)
+    end
+
     it "should return the first node in the queue sorted by field" do
       task.queue("cops").push(create(:user, name: "John"))
       task.queue("cops").push(create(:user, name: "Bob"))

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_06_144346) do
+ActiveRecord::Schema.define(version: 2024_05_07_112811) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,7 +23,7 @@ ActiveRecord::Schema.define(version: 2021_08_06_144346) do
     t.integer "kind"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index %w(nodable_type nodable_id), name: "index_queue_it_nodes_on_nodable"
+    t.index ["nodable_type", "nodable_id"], name: "index_queue_it_nodes_on_nodable"
     t.index ["parent_node_id"], name: "index_queue_it_nodes_on_parent_node_id"
     t.index ["queue_id"], name: "index_queue_it_nodes_on_queue_id"
   end
@@ -33,7 +34,9 @@ ActiveRecord::Schema.define(version: 2021_08_06_144346) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "count_of_nodes", default: 0
-    t.index %w(queable_type queable_id), name: "index_queue_it_queues_on_queable"
+    t.string "name"
+    t.index ["name", "queable_type", "queable_id"], name: "index_queue_it_queues_on_name_and_queable_type_and_queable_id", unique: true
+    t.index ["queable_type", "queable_id"], name: "index_queue_it_queues_on_queable"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -47,4 +50,5 @@ ActiveRecord::Schema.define(version: 2021_08_06_144346) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
+
 end


### PR DESCRIPTION
Sort by exp and nodable order. The issue was that if the expression for sorting had yielded the same value for both a and b, then it was not sorting by nodable order.

Added tests to reflect this for nodables, peek, pop, shift.

I have set this up to run locally on docker compose which i didn't put up yet