### PR TITLE
Fix removed callback; Remove deprecated methods; Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Ruby 2.7 image for ARM architecture
+FROM ruby:2.7.8-bullseye
+
+# Install Bundler version 2.2.34
+RUN gem install bundler -v 2.2.34
+
+# Set up the work directory
+WORKDIR /usr/src/app
+
+# Copy the gemspec and all required files for it
+COPY queue_it.gemspec ./
+
+# Copy the Gemfile and Gemfile.lock into the container
+COPY Gemfile* ./
+
+# Install the required gems
+RUN bundle install
+
+# Copy the rest of your application code
+COPY . .
+
+# Command to run your test suite
+CMD ["bundle", "exec", "rake", "test"]

--- a/app/lib/queue_it/queue_api.rb
+++ b/app/lib/queue_it/queue_api.rb
@@ -86,7 +86,7 @@ class QueueIt::QueueApi
   end
 
   def remove(nodable)
-    removed = ActiveRecord::Base.transaction do
+    ActiveRecord::Base.transaction do
       queue.lock!
 
       nodes = queue.nodes.where(nodable: nodable)
@@ -94,7 +94,7 @@ class QueueIt::QueueApi
       nodes.any?
     end
 
-    emit_event(nodable, "remove") if removed
+    emit_event(nodable, "remove")
 
     self
   end

--- a/app/models/concerns/queue_it/queable_by_name.rb
+++ b/app/models/concerns/queue_it/queable_by_name.rb
@@ -3,7 +3,7 @@ module QueueIt::QueableByName
 
   included do
     has_many :queues,
-            as: :queable, inverse_of: :queable, dependent: :destroy, class_name: 'QueueIt::Queue'
+             as: :queable, inverse_of: :queable, dependent: :destroy, class_name: 'QueueIt::Queue'
 
     def find_or_create_queue!(name)
       QueueIt::Queue.find_or_create_by!(queable: self, name: name)

--- a/app/models/concerns/queue_it/queable_by_name.rb
+++ b/app/models/concerns/queue_it/queable_by_name.rb
@@ -9,128 +9,15 @@ module QueueIt::QueableByName
       QueueIt::Queue.find_or_create_by!(queable: self, name: name)
     end
 
-    def push_to_queue(name, nodable, in_head = true, skip_callback = false)
-      if local_queue(name).empty?
-        local_queue(name).push_node_when_queue_length_is_zero(nodable, skip_callback)
-      elsif local_queue(name).one_node?
-        local_queue(name).push_node_when_queue_length_is_one(nodable, in_head, skip_callback)
-      else
-        in_head ? local_queue(name).push_in_head(nodable, skip_callback) : local_queue(name).push_in_tail(nodable, skip_callback)
-      end
-    end
-
-    def get_next_in_queue_by(name, nodable_attribute, attribute_value)
-      get_next_node_in_queue_by(name, nodable_attribute, attribute_value)&.nodable
-    end
-
-    def get_next_node_in_queue_by(name, nodable_attribute, attribute_value)
-      return if local_queue(name).empty?
-
-      if local_queue(name).one_node?
-        return local_queue(name).get_next_by_with_queue_length_one(nodable_attribute, attribute_value)
-      elsif local_queue(name).two_nodes?
-        return local_queue(name).get_next_by_with_queue_length_two(nodable_attribute, attribute_value)
-      end
-
-      local_queue(name).get_next_by_in_generic_queue(nodable_attribute, attribute_value)
-    end
-
-    def get_next_in_queue(name)
-      get_next_node_in_queue(name)&.nodable
-    end
-
-    def get_next_node_in_queue(name)
-      return if local_queue(name).empty?
-
-      if local_queue(name).one_node?
-        local_queue(name).head_node
-      elsif local_queue(name).two_nodes?
-        local_queue(name).get_next_in_queue_with_length_two
-      else
-        local_queue(name).get_next_in_queue_generic
-      end
-    end
-
-    def formatted_queue(name, nodable_attribute)
-      return if local_queue(name).empty?
-      return [local_queue(name).head_node.nodable.send(nodable_attribute)] if local_queue(name).one_node?
-
-      formatted_generic_queue(name, nodable_attribute)
-    end
-
-    def peek_next_in_queue_by(name, nodable_attribute, attribute_value)
-      peek_next_node_in_queue_by(name, nodable_attribute, attribute_value)&.nodable
-    end
-
-    def peek_next_node_in_queue_by(name, nodable_attribute, attribute_value)
-      return if local_queue(name).empty?
-
-      if local_queue(name).one_node?
-        return local_queue(name).peek_next_by_with_queue_length_one(nodable_attribute, attribute_value)
-      elsif local_queue(name).two_nodes?
-        return local_queue(name).peek_next_by_with_queue_length_two(nodable_attribute, attribute_value)
-      end
-
-      local_queue(name).peek_next_by_in_generic_queue(nodable_attribute, attribute_value)
-    end
-
-    def peek_next_in_queue(name)
-      local_queue(name).peek_next_in_queue_generic&.nodable
-    end
-
     def delete_queue_nodes(name)
-      local_queue(name).nodes.delete_all
-      local_queue(name).count_of_nodes = 0
-      local_queue(name).save
-    end
-
-    def pop_from_queue(name, skip_callback = false)
-      nodable = nil
-      ActiveRecord::Base.transaction do
-        local_queue(name).lock!
-
-        nodable = get_next_in_queue(name)
-        local_queue(name).nodes.where(nodable: nodable).find_each do |node|
-          remove_node(node)
-        end
-      end
-
-      after_commit_handler(name, nodable, "remove") if nodable.present? && skip_callback
-      nodable
-    end
-
-    def pop_from_queue_by(name, nodable_attribute, attribute_value, skip_callback = false)
-      nodable = nil
-      ActiveRecord::Base.transaction do
-        local_queue(name).lock!
-
-        nodable = get_next_in_queue_by(name, nodable_attribute, attribute_value)
-        local_queue(name).nodes.where(nodable: nodable).find_each do |node|
-          remove_node(node)
-        end
-      end
-
-      after_commit_handler(name, nodable, "remove") if nodable.present? && skip_callback
-      nodable
-    end
-
-    def remove_from_queue(name, nodable, skip_callback = false)
-      return if local_queue(name).empty? || local_queue(name).nodes.where(nodable: nodable).empty?
-
-      ActiveRecord::Base.transaction do
-        local_queue(name).lock!
-        local_queue(name).nodes.where(nodable: nodable).find_each do |node|
-          remove_node(node)
-        end
-      end
-
-      after_commit_handler(name, nodable, "remove") unless skip_callback
-      nodable
+      queue(name).nodes.delete_all
+      queue(name).count_of_nodes = 0
+      queue(name).save
     end
 
     def connected_nodes(name)
       counter = 0
-      current_node = local_queue(name).head_node
+      current_node = queue(name).head_node
       while !current_node.nil?
         counter += 1
         current_node = current_node.child_node
@@ -138,39 +25,8 @@ module QueueIt::QueableByName
       counter
     end
 
-    def local_queue(name)
-      find_or_create_queue!(name)
-    end
-
     def queue(name)
-      QueueIt::QueueApi.new(self, local_queue(name))
+      QueueIt::QueueApi.new(self, find_or_create_queue!(name))
     end
-
-    private
-
-    def remove_node(node)
-      node.reload
-      previous_node = node.parent_node
-      child_node = node.child_node
-      node_kind = node.kind
-      node.destroy
-      new_child_node_kind = node_kind == 'head' ? node_kind : child_node&.kind
-      child_node&.update!(parent_node: previous_node, kind: new_child_node_kind)
-      previous_node&.update!(kind: node_kind) if node_kind == 'tail' && previous_node&.any?
-    end
-  end
-
-  def formatted_generic_queue(name, nodable_attribute)
-    current_node = local_queue(name).head_node
-    array = []
-    while !current_node.nil?
-      array.push(current_node.nodable.send(nodable_attribute))
-      current_node = current_node.child_node
-    end
-    array
-  end
-
-  def after_commit_handler(name, nodable, operation)
-    QueueIt.queue_callback.call(self, name, nodable, operation) if QueueIt.queue_callback.respond_to?(:call)
   end
 end

--- a/app/models/queue_it/queue.rb
+++ b/app/models/queue_it/queue.rb
@@ -100,16 +100,16 @@ module QueueIt
       end
     end
 
-    def push_node_when_queue_length_is_zero(nodable, _emit_callbacks = true)
+    def push_node_when_queue_length_is_zero(nodable)
       ActiveRecord::Base.transaction do
         lock!
         nodes.create!(nodable: nodable, kind: :head)
       end
     end
 
-    def push_node_when_queue_length_is_one(nodable, in_head, emit_callbacks = true)
+    def push_node_when_queue_length_is_one(nodable, in_head)
       if in_head
-        push_in_head(nodable, emit_callbacks)
+        push_in_head(nodable)
       else
         ActiveRecord::Base.transaction do
           lock!
@@ -120,7 +120,7 @@ module QueueIt
       nodable
     end
 
-    def push_in_head(nodable, _emit_callbacks = true)
+    def push_in_head(nodable)
       ActiveRecord::Base.transaction do
         lock!
         old_head_node = head_node&.lock!
@@ -133,7 +133,7 @@ module QueueIt
       nodable
     end
 
-    def push_in_tail(nodable, _emit_callbacks = true)
+    def push_in_tail(nodable)
       ActiveRecord::Base.transaction do
         lock!
         old_tail_node = tail_node&.lock!

--- a/app/models/queue_it/queue.rb
+++ b/app/models/queue_it/queue.rb
@@ -100,40 +100,6 @@ module QueueIt
       end
     end
 
-    def peek_next_by_with_queue_length_one(nodable_attribute, attribute_value)
-      head_node if head_node&.nodable.send(nodable_attribute) == attribute_value
-    end
-
-    def peek_next_by_with_queue_length_two(nodable_attribute, attribute_value)
-      if head_node&.nodable.send(nodable_attribute) == attribute_value
-        head_node
-      elsif tail_node&.nodable.send(nodable_attribute) == attribute_value
-        tail_node
-      end
-    end
-
-    def peek_next_by_in_generic_queue(nodable_attribute, attribute_value)
-      if head_node&.nodable.send(nodable_attribute) == attribute_value
-        return head_node
-      end
-
-      current_node = head_node&.child_node
-      return unless current_node
-
-      while !(current_node&.nodable.send(nodable_attribute) == attribute_value &&
-          current_node != tail_node)
-        current_node = current_node&.child_node
-        break if current_node == tail_node
-      end
-      if current_node&.nodable.send(nodable_attribute) == attribute_value
-        current_node != tail_node ? current_node : tail_node
-      end
-    end
-
-    def peek_next_in_queue_generic
-      head_node
-    end
-
     def push_node_when_queue_length_is_zero(nodable, _emit_callbacks = true)
       ActiveRecord::Base.transaction do
         lock!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: my_database
+    ports:
+      - "5433:5432"
+
+  app:
+    build: .
+    command: /bin/bash
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "3011:3000"
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgres://postgres:password@db:5432/my_database

--- a/spec/concerns/queue_it/queable_by_name_spec.rb
+++ b/spec/concerns/queue_it/queable_by_name_spec.rb
@@ -467,56 +467,10 @@ describe 'Concerns::QueableByName' do
     end
   end
 
-  # deprecated
   describe '#find_or_create_queue!' do
     it "should return the queue with the given name" do
       queue = task.find_or_create_queue!("cops")
       expect(queue.name).to eq("cops")
-    end
-  end
-
-  # deprecated
-  describe '#push_to_queue' do
-    context 'when queue is empty' do
-      it "should push the nodable to the queue" do
-        queue = task.find_or_create_queue!("cops")
-        nodable = create(:user, name: "Bob")
-
-        expect(queue.nodes.count).to eq(0)
-        task.push_to_queue("cops", nodable)
-        expect(queue.nodes.count).to eq(1)
-      end
-    end
-
-    context 'when queue has 1 node already' do
-      it "should push the nodable to the queue" do
-        queue = task.find_or_create_queue!("cops")
-        nodable1 = create(:user, name: "Bob")
-        nodable2 = create(:user, name: "Xia")
-
-        task.push_to_queue("cops", nodable1)
-        expect(queue.nodes.count).to eq(1)
-        task.push_to_queue("cops", nodable2)
-        expect(queue.nodes.count).to eq(2)
-      end
-    end
-
-    context 'when queue has more than 1 node already' do
-      it "should push the nodable to the queue" do
-        queue = task.find_or_create_queue!("cops")
-        nodable1 = create(:user, name: "Bob")
-        nodable2 = create(:user, name: "Xia")
-        nodable3 = create(:user, name: "John")
-
-        task.push_to_queue("cops", nodable1)
-        task.push_to_queue("cops", nodable2)
-        expect(queue.nodes.count).to eq(2)
-        expect(queue.head_node.nodable).to eq(nodable2)
-
-        task.push_to_queue("cops", nodable3, false)
-        expect(queue.nodes.count).to eq(3)
-        expect(queue.tail_node.nodable).to eq(nodable3)
-      end
     end
   end
 

--- a/spec/concerns/queue_it/queable_by_name_spec.rb
+++ b/spec/concerns/queue_it/queable_by_name_spec.rb
@@ -372,6 +372,18 @@ describe 'Concerns::QueableByName' do
   end
 
   describe '#remove' do
+    it "should not trigger callback if none were removed" do
+      john = create(:user, name: "John")
+      bob = create(:user, name: "Bob")
+      task.queue("cops").push(john)
+
+      queue_callback = double("QueueCallback")
+      expect(queue_callback).to receive(:call).never
+      expect(QueueIt).to receive(:queue_callback).and_return(queue_callback).never
+
+      task.queue("cops").remove(bob)
+    end
+
     it "should remove the nodable from the queue" do
       john = create(:user, name: "John")
       bob = create(:user, name: "Bob")

--- a/spec/concerns/queue_it/queable_by_name_spec.rb
+++ b/spec/concerns/queue_it/queable_by_name_spec.rb
@@ -206,7 +206,7 @@ describe 'Concerns::QueableByName' do
   end
 
   describe '#nodables' do
-    it "should return the nodes in the queue sorted using the given sort expression and nodable order" do
+    it "returns the nodes in the queue sorted using the given sort expression and nodable order" do
       task.queue("cops").push(create(:user, name: "Edward"))
       task.queue("cops").push(create(:user, name: "Amy"))
       task.queue("cops").push(create(:user, name: "Bob"))
@@ -236,7 +236,7 @@ describe 'Concerns::QueableByName' do
       expect(result.map(&:name)).to eq(%w(Edward David Frank Cindy Bob Amy))
     end
 
-    it "should return the nodes in the queue sorted using the given sort expression and sort order" do
+    it "returns the nodes in the queue sorted using the given sort expression and sort order" do
       task.queue("cops").push(create(:user, name: "Bob"))
       task.queue("cops").push(create(:user, name: "Xia"))
       task.queue("cops").push(create(:user, name: "John"))
@@ -272,7 +272,8 @@ describe 'Concerns::QueableByName' do
       expect(result.map(&:name)).not_to include("Xia")
     end
 
-    it "should return the nodes in the queue that match the given filter expression and sorted using the given sort expression and sort order" do
+    it "returns the nodes in the queue that match the given filter expression and sorted \
+      using the given sort expression and sort order" do
       task.queue("cops").push(create(:user, name: "Bob"))
       task.queue("cops").push(create(:user, name: "Xia"))
       task.queue("cops").push(create(:user, name: "John"))
@@ -291,7 +292,8 @@ describe 'Concerns::QueableByName' do
       expect(result.map(&:name)).to eq(%w(John Bob))
     end
 
-    it "should return the nodes in the order they were added to the queue if no sort expression is given" do
+    it "returns the nodes in the order they were added to the queue if no sort expression \
+      is given" do
       task.queue("cops").push(create(:user, name: "Bob"))
       task.queue("cops").push(create(:user, name: "Xia"))
       task.queue("cops").unshift(create(:user, name: "John"))
@@ -414,7 +416,7 @@ describe 'Concerns::QueableByName' do
   end
 
   describe '#suppress_callbacks' do
-    it "should not call queue_callback when queue is modified inside the suppress_callbacks block" do
+    it "does not call queue_callback when queue is modified inside the suppress_callbacks block" do
       queue = task.queue("cops")
 
       queue.push(create(:user, name: "Bob"))

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2024_05_07_112811) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,7 +22,7 @@ ActiveRecord::Schema.define(version: 2024_05_07_112811) do
     t.integer "kind"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["nodable_type", "nodable_id"], name: "index_queue_it_nodes_on_nodable"
+    t.index %w(nodable_type nodable_id), name: "index_queue_it_nodes_on_nodable"
     t.index ["parent_node_id"], name: "index_queue_it_nodes_on_parent_node_id"
     t.index ["queue_id"], name: "index_queue_it_nodes_on_queue_id"
   end
@@ -35,8 +34,9 @@ ActiveRecord::Schema.define(version: 2024_05_07_112811) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "count_of_nodes", default: 0
     t.string "name"
-    t.index ["name", "queable_type", "queable_id"], name: "index_queue_it_queues_on_name_and_queable_type_and_queable_id", unique: true
-    t.index ["queable_type", "queable_id"], name: "index_queue_it_queues_on_queable"
+    t.index %w(name queable_type queable_id),
+            name: "index_queue_it_queues_on_name_and_queable_type_and_queable_id", unique: true
+    t.index %w(queable_type queable_id), name: "index_queue_it_queues_on_queable"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -50,5 +50,4 @@ ActiveRecord::Schema.define(version: 2024_05_07_112811) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
-
 end


### PR DESCRIPTION
Fix removed callback
  - bug fix to address "#remove" did not trigger callbacks at all
Remove deprecated methods
  - removing these in favour of the new api in queue_api
Dockerfile
  - for running tests locally
  - can just run:
    - docker-compose run app 
    - rspec .
    - rubocop .